### PR TITLE
feat: let ParseTolerant remove leading zeros from version digits

### DIFF
--- a/semver.go
+++ b/semver.go
@@ -202,14 +202,19 @@ func Make(s string) (Version, error) {
 
 // ParseTolerant allows for certain version specifications that do not strictly adhere to semver
 // specs to be parsed by this library. It does so by normalizing versions before passing them to
-// Parse(). It currently trims spaces, removes a "v" prefix, and adds a 0 patch number to versions
-// with only major and minor components specified
+// Parse(). It currently trims spaces, removes a "v" prefix, adds a 0 patch number to versions
+// with only major and minor components specified, and removes leading 0s.
 func ParseTolerant(s string) (Version, error) {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "v")
 
 	// Split into major.minor.(patch+pr+meta)
 	parts := strings.SplitN(s, ".", 3)
+	// Remove leading zeros.
+	for i, p := range parts {
+		parts[i] = strings.TrimPrefix(p, "0")
+	}
+	// Fill up shortened versions.
 	if len(parts) < 3 {
 		if strings.ContainsAny(parts[len(parts)-1], "+-") {
 			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
@@ -217,8 +222,8 @@ func ParseTolerant(s string) (Version, error) {
 		for len(parts) < 3 {
 			parts = append(parts, "0")
 		}
-		s = strings.Join(parts, ".")
 	}
+	s = strings.Join(parts, ".")
 
 	return Parse(s)
 }

--- a/semver_test.go
+++ b/semver_test.go
@@ -33,6 +33,7 @@ var formatTests = []formatTest{
 var tolerantFormatTests = []formatTest{
 	{Version{1, 2, 3, nil, nil}, "v1.2.3"},
 	{Version{1, 2, 3, nil, nil}, "	1.2.3 "},
+	{Version{1, 2, 3, nil, nil}, "01.02.03"},
 	{Version{1, 2, 0, nil, nil}, "1.2"},
 	{Version{1, 0, 0, nil, nil}, "1"},
 }


### PR DESCRIPTION
Various vendors use versions with leading zeros (e.g., Docker, 18.09).
Let semver accept them in its tolerant parser.